### PR TITLE
Preserve string case after translit

### DIFF
--- a/CyrillicToTranslit.js
+++ b/CyrillicToTranslit.js
@@ -76,6 +76,7 @@ module.exports = function cyrillicToTranslit(config) {
 
     let newStr = "";
     for (let i = 0; i < input.length; i++) {
+      const isUpperCaseOrWhatever = input[i] === input[i].toUpperCase();
       let strLowerCase = input[i].toLowerCase();
       if (strLowerCase === " " && spaceReplacement) {
         newStr += spaceReplacement;
@@ -85,10 +86,10 @@ module.exports = function cyrillicToTranslit(config) {
         ? "gh"
         : (i === 0 ? _firstLetterAssociations : _associations)[strLowerCase];
       if ("undefined" === typeof newLetter) {
-        newStr += strLowerCase;
+        newStr += isUpperCaseOrWhatever ? strLowerCase.toUpperCase() : strLowerCase;
       }
       else {
-        newStr += newLetter;
+        newStr += isUpperCaseOrWhatever ? newLetter.toUpperCase() : newLetter;
       }
     }
     return newStr;


### PR DESCRIPTION
This change preserves case of a character after it's been transliterated. E.g. `Пройдeмте, Гражданин` -> `Proidemte, Grazhdanin`.