### PR TITLE
Reverse translit implementation

### DIFF
--- a/CyrillicToTranslit.js
+++ b/CyrillicToTranslit.js
@@ -3,22 +3,18 @@
 module.exports = function cyrillicToTranslit(config) {
   const _preset = config ? config.preset : "ru";
 
-  const _firstLetterAssociations = {
+  /*
+  ASSOCIATIONS FOR INITIAL POSITION
+  */
+
+  // letters shared between languages
+  const _firstLetters = {
     "а": "a",
     "б": "b",
     "в": "v",
-    "ґ": "g",
-    "г": "g",
     "д": "d",
-    "е": "e",
-    "ё": "e",
-    "є": "ye",
-    "ж": "zh",
     "з": "z",
-    "и": "i",
-    "і": "i",
-    "ї": "yi",
-    "й": "i",
+    "й": "y",
     "к": "k",
     "л": "l",
     "м": "m",
@@ -30,44 +26,76 @@ module.exports = function cyrillicToTranslit(config) {
     "т": "t",
     "у": "u",
     "ф": "f",
-    "х": "h",
-    "ц": "c",
-    "ч": "ch",
-    "ш": "sh",
-    "щ": "sh'",
-    "ъ": "",
-    "ы": "i",
-    "ь": "",
-    "э": "e",
-    "ю": "yu",
-    "я": "ya",
+    "ь": ""
   };
 
-  if (_preset === "uk") {
-    Object.assign(_firstLetterAssociations, {
+  // language-specific letters
+  if (_preset === "ru") {
+    Object.assign(_firstLetters, {
+      "г": "g",
+      "и": "i",
+      "ъ": "",
+      "ы": "i",
+      "э": "e",
+    });
+  } else if (_preset === "uk") {
+    Object.assign(_firstLetters, {
       "г": "h",
+      "ґ": "g",
+      "е": "e",
       "и": "y",
-      "й": "y",
-      "х": "kh",
-      "ц": "ts",
-      "щ": "shch",
+      "і": "i",
       "'": "",
       "’": "",
       "ʼ": "",
-    });
+    })
   }
 
-  const _associations = Object.assign({}, _firstLetterAssociations);
+  // digraphs appearing only in initial position
+  const _initialDigraphs = (_preset === "ru") ? { "е": "ye" } : { "є": "ye", "ї": "yi" };
 
+  // digraphs appearing in all positions
+  const _regularDigraphs = {
+    "ё": "yo",
+    "ж": "zh",
+    "х": "kh",
+    "ц": "ts",
+    "ч": "ch",
+    "ш": "sh",
+    "щ": "shch",
+    "ю": "yu",
+    "я": "ya",
+  }
+
+  const _firstDigraphs = { ..._regularDigraphs, ..._initialDigraphs };
+
+  const _firstAssociations = { ..._firstLetters, ..._firstDigraphs };
+
+  /*
+  ASSOCIATIONS FOR NON-INITIAL POSITION
+  */
+
+  const _nonFirstLetters = { ..._firstLetters, "й": "i" };
+  if (_preset === "ru") {
+    Object.assign(_nonFirstLetters, { "е": "e" });
+  } else if (_preset === "uk") {
+    Object.assign(_nonFirstLetters, { "ї": "i" });
+  }
+
+  // digraphs appearing only in non-initial positions
+  let _nonInitialDigraphs = {};
   if (_preset === "uk") {
-    Object.assign(_associations, {
+    _nonInitialDigraphs = {
       "є": "ie",
-      "ї": "i",
-      "й": "i",
       "ю": "iu",
       "я": "ia",
-    });
+    };
   }
+
+  const _nonFirstDigraphs = { ..._regularDigraphs, ..._nonInitialDigraphs };
+
+  const _nonFirstAssociations = { ..._nonFirstLetters, ..._nonFirstDigraphs };
+
 
   function transform(input, spaceReplacement) {
     if (!input) {
@@ -88,7 +116,7 @@ module.exports = function cyrillicToTranslit(config) {
       }
       let newLetter = _preset === "uk" && strLowerCase === "г" && i > 0 && normalizedInput[i - 1].toLowerCase() === "з"
         ? "gh"
-        : (i === 0 ? _firstLetterAssociations : _associations)[strLowerCase];
+        : (i === 0 ? _firstAssociations : _nonFirstAssociations)[strLowerCase];
       if ("undefined" === typeof newLetter) {
         newStr += isUpperCaseOrWhatever ? strLowerCase.toUpperCase() : strLowerCase;
       }

--- a/CyrillicToTranslit.js
+++ b/CyrillicToTranslit.js
@@ -228,7 +228,6 @@ module.exports = function cyrillicToTranslit(config) {
 
       if ("undefined" === typeof newLetter) {
         newStr += isUpperCaseOrWhatever ? strLowerCase.toUpperCase() : strLowerCase;
-        i++;
       }
       else {
         if (isUpperCaseOrWhatever) {

--- a/CyrillicToTranslit.js
+++ b/CyrillicToTranslit.js
@@ -188,8 +188,8 @@ module.exports = function cyrillicToTranslit(config) {
       let strLowerCase = normalizedInput[i].toLowerCase();
       let currentIndex = i;
 
-      if (strLowerCase === " ") {
-        spaceReplacement ? newStr += spaceReplacement : newStr += " ";
+      if (strLowerCase === " " || strLowerCase === spaceReplacement) {
+        newStr += " ";
         isWordBoundary = true;
         i++;
         continue;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4150,6 +4150,11 @@
       "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
       "dev": true
     },
+    "lodash.invert": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.invert/-/lodash.invert-4.3.0.tgz",
+      "integrity": "sha1-j/4g1LYW9WvqjxqgxuvYDc90Ku4="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
   "bugs": {
     "url": "https://github.com/greybax/CyrillicToTranslitJS/issues"
   },
-  "homepage": "https://github.com/greybax/CyrillicToTranslitJS#readme"
+  "homepage": "https://github.com/greybax/CyrillicToTranslitJS#readme",
+  "dependencies": {
+    "lodash.invert": "^4.3.0"
+  }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -58,5 +58,8 @@ describe('cyrillicToTranslit', () => {
     it('should return plain cyrillic with reversing translit with space replacement', () => {
       assert.equal("привіт світе", cyrillicToTranslit({ preset: "uk" }).reverse("pryvit_svite", "_"));
     });
+    it('should return cyrillic if cyrillic is passed to reverse', () => {
+      assert.equal("привет мир!", cyrillicToTranslit().reverse("привет мир!"));
+    });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -55,5 +55,8 @@ describe('cyrillicToTranslit', () => {
         cyrillicToTranslit({ preset: "uk" }).reverse("Rozghon Uliana i Harashchenko Khrystyna")
       );
     });
+    it('should return plain cyrillic with reversing translit with space replacement', () => {
+      assert.equal("привіт світе", cyrillicToTranslit({ preset: "uk" }).reverse("pryvit_svite", "_"));
+    });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -29,7 +29,7 @@ describe('cyrillicToTranslit', () => {
       assert.equal("novii_podezd", cyrillicToTranslit().transform("новый подъезд", '_'));
     });
     it('should return translit when first parameter cyrillic whith using ь', () => {
-      assert.equal("plohaya_svyaz", cyrillicToTranslit().transform("плохая связь", '_'));
+      assert.equal("plokhaya_svyaz", cyrillicToTranslit().transform("плохая связь", '_'));
     });
     it('should return translit with replaced " " on "_"', () => {
       assert.equal("privet_mir!", cyrillicToTranslit().transform("привет мир!", "_"));

--- a/test/test.js
+++ b/test/test.js
@@ -16,7 +16,7 @@ describe('cyrillicToTranslit', () => {
       assert.equal("", cyrillicToTranslit().transform());
       assert.equal("", cyrillicToTranslit().transform(null));
     });
-    it('should return translit when cyrillic string not nomalized', () => {
+    it('should return translit when cyrillic string not normalized', () => {
       assert.equal("russkii", cyrillicToTranslit().transform("русский".normalize('NFD')));
     });
     it('should return translit when first parameter cyrillic', () => {
@@ -25,17 +25,35 @@ describe('cyrillicToTranslit', () => {
     it('should return translit when first parameter cyrillic with using ыьъ', () => {
       assert.equal("uchebnii_material_1!", cyrillicToTranslit().transform("учебный материал 1ьъ!", '_'));
     });
-    it('should return translit when first parameter cyrillic whith using ъ', () => {
+    it('should return translit when first parameter cyrillic with using ъ', () => {
       assert.equal("novii_podezd", cyrillicToTranslit().transform("новый подъезд", '_'));
     });
-    it('should return translit when first parameter cyrillic whith using ь', () => {
+    it('should return translit when first parameter cyrillic with using ь', () => {
       assert.equal("plokhaya_svyaz", cyrillicToTranslit().transform("плохая связь", '_'));
+    });
+    it('should handle й in first position and other positions differently', () => {
+      assert.equal("vkusnii yogurt", cyrillicToTranslit().transform("вкусный йогурт"));
+    });
+    it('should transform digraphs to uppercase correctly', () => {
+      assert.equal("Yaroslavl i Yekaterinburg", cyrillicToTranslit().transform("Ярославль и Екатеринбург"));
     });
     it('should return translit with replaced " " on "_"', () => {
       assert.equal("privet_mir!", cyrillicToTranslit().transform("привет мир!", "_"));
     });
     it('should return translit if translit passed', () => {
       assert.equal("privet mir!", cyrillicToTranslit().transform("privet mir!"));
+    });
+    it('should return cyrillic when using reverse function for Russian', () => {
+      assert.equal(
+        "улица Союза Печатников", 
+        cyrillicToTranslit().reverse("ulitsa Soyuza Pechatnikov")
+      );
+    });
+    it('should return cyrillic when using reverse function for Ukrainian', () => {
+      assert.equal(
+        "Розгон Уляна і Гаращенко Христина", 
+        cyrillicToTranslit({ preset: "uk" }).reverse("Rozghon Uliana i Harashchenko Khrystyna")
+      );
     });
   });
 });


### PR DESCRIPTION
Hello! I found your package looking for reverse transliteration and since I didn't find anything, I decided to try to implement it myself. This should resolve #61 

I had to separate digraphs from simple letters, so I made some significant changes to the letter mappings. I also made ц > ts, х  > kh, щ > shch shared for Russian and Ukrainian to simplify a bit (there are many standards for Russian that support that, according to [wikipedia](https://ru.wikipedia.org/wiki/%D0%A2%D1%80%D0%B0%D0%BD%D1%81%D0%BB%D0%B8%D1%82%D0%B5%D1%80%D0%B0%D1%86%D0%B8%D1%8F_%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%BE%D0%B3%D0%BE_%D0%B0%D0%BB%D1%84%D0%B0%D0%B2%D0%B8%D1%82%D0%B0_%D0%BB%D0%B0%D1%82%D0%B8%D0%BD%D0%B8%D1%86%D0%B5%D0%B9))

I also noticed issues with uppercase conversion and word boundaries (first letter associations applied only to the first letter of the whole string), so I fixed those.

I hope I'm not out of line here. This is actually my first pull request 😬