### PR TITLE
Correct typings to make it true

### DIFF
--- a/CyrillicToTranslit.d.ts
+++ b/CyrillicToTranslit.d.ts
@@ -1,14 +1,11 @@
-// Type definitions for cyrillic-to-translit-js 2.0.0
-// Project: https://github.com/greybax/cyrillic-to-translit-js
-// Definitions by: makepost <https://github.com/makepost>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export = CyrillicToTranslit;
-
-declare class CyrillicToTranslit {
-  constructor(config?: { preset: "ru" | "uk" });
-
-  public transform(input: string, spaceReplacement?: string): string;
-
-  public reverse(input: string, spaceReplacement?: string): string;
+export interface CyrillicToTranslit {
+  (config?: { preset: "ru" | "uk" }): {
+    transform(input: string, spaceReplacement?: string): string;
+    reverse(input: string, spaceReplacement?: string): string;
+  }
 }
+
+declare const cyrillicToTranslit: CyrillicToTranslit  
+
+export default cyrillicToTranslit


### PR DESCRIPTION
Current typings are strange.

This allows using package function as intended.

```ts
import cyrillicToTranslit from 'cyrillic-to-translit-js'

const translit = cyrillicToTranslit({preset: 'ru'})
translit.transform(...)
```